### PR TITLE
Add Python 3 compatibility string for Py2 & 3

### DIFF
--- a/octoprint_CR10_Leveling/__init__.py
+++ b/octoprint_CR10_Leveling/__init__.py
@@ -71,6 +71,7 @@ class Cr10_levelingPlugin(octoprint.plugin.AssetPlugin,
 
 
 __plugin_name__ = "Bed Leveling Plugin"
+__plugin_pythoncompat__ = ">=2.7, <4"
 
 
 def __plugin_load__():


### PR DESCRIPTION
Since Python 2 is EOL and all new users very shortly will be Py3, they would not be able to install and run this plugin.

There's the documentation here, if you want to setup dual environments for testing:
https://docs.octoprint.org/en/master/plugins/python3_migration.html

Or, to update your existing environment, one time script:
https://octoprint.org/blog/2020/09/10/upgrade-to-py3/

Closes #27 
Closes #28

Until this PR gets merged, and you (as a user) want to install the plugin - use this URL in the plugin manager > Get More> ...from URL:
```
https://github.com/cp2004/OctoPrint-Cr10_leveling/archive/patch-1.zip
```