### PR TITLE
Python 3 compatibility property

### DIFF
--- a/octoprint_CR10_Leveling/__init__.py
+++ b/octoprint_CR10_Leveling/__init__.py
@@ -21,6 +21,7 @@ from __future__ import absolute_import
 from octoprint.settings import settings
 import octoprint.plugin
 
+__plugin_pythoncompat__ = ">=2.7,<4"
 
 class Cr10_levelingPlugin(octoprint.plugin.AssetPlugin,
                           octoprint.plugin.TemplatePlugin,


### PR DESCRIPTION
Plugin wasn't compatible with my new Octoprint installation, because of Python version.
See: [Python 3 Migration](https://docs.octoprint.org/en/master/plugins/python3_migration.html#telling-octoprint-your-plugin-is-python-3-ready)